### PR TITLE
feat: add site header with navigation

### DIFF
--- a/jewelrysite-frontend/src/components/Header.tsx
+++ b/jewelrysite-frontend/src/components/Header.tsx
@@ -1,0 +1,41 @@
+import { Link, useLocation } from "react-router-dom";
+
+export default function Header() {
+    const location = useLocation();
+    const BRAND = "#6B8C8E";
+
+    const links = [
+        { to: "/", label: "Home" },
+        { to: "/catalog", label: "Catalog" }
+    ];
+
+    const filteredLinks = links.filter(link => link.to !== location.pathname);
+
+    return (
+        <header className="flex flex-col items-center mb-8">
+            <h1
+                className="text-3xl font-extrabold tracking-wide text-center"
+                style={{ color: BRAND, textShadow: "0 1px 0 rgba(0,0,0,0.05)" }}
+            >
+                EDTArt
+            </h1>
+            <div
+                className="h-1.5 w-28 rounded-full mt-1"
+                style={{ background: `linear-gradient(90deg, ${BRAND}, ${BRAND}80)` }}
+            />
+            <nav className="mt-4 flex gap-4">
+                {filteredLinks.map(link => (
+                    <Link
+                        key={link.to}
+                        to={link.to}
+                        className="text-lg font-medium hover:underline"
+                        style={{ color: BRAND }}
+                    >
+                        {link.label}
+                    </Link>
+                ))}
+            </nav>
+        </header>
+    );
+}
+

--- a/jewelrysite-frontend/src/pages/CatalogPage.tsx
+++ b/jewelrysite-frontend/src/pages/CatalogPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import JewelryCard from "../components/JewelryCard";
 import { getCatalog, getCategories, getCollections } from "../api/jewelry";
 import type { JewelryItemForCard } from "../types/JewelryItemForCard";
+import Header from "../components/Header";
 
 export default function CatalogPage() {
     const [sortType, setSortType] = useState<"category" | "collection" | "">("");
@@ -46,6 +47,7 @@ export default function CatalogPage() {
 
     return (
         <div className="min-h-screen p-6" style={{ backgroundColor: "#fbfbfa" }}>
+            <Header />
             {/* Header Section */}
             <div className="mb-8 flex flex-col items-center">
                 <h1

--- a/jewelrysite-frontend/src/pages/HomePage.tsx
+++ b/jewelrysite-frontend/src/pages/HomePage.tsx
@@ -1,9 +1,14 @@
+import Header from "../components/Header";
+
 export default function HomePage() {
     return (
-        <main className="p-6">
-            <div className="m-4 p-4 rounded-xl bg-blue-600 text-white">
-                Tailwind OK
-            </div>
-        </main>
+        <div className="min-h-screen p-6 bg-[#fbfbfa]">
+            <Header />
+            <main className="p-6">
+                <div className="m-4 p-4 rounded-xl bg-blue-600 text-white">
+                    Tailwind OK
+                </div>
+            </main>
+        </div>
     );
 }

--- a/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
+++ b/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { getJewelryItemById } from "../api/jewelry";
+import Header from "../components/Header";
 
 export default function JewelryItemPage() {
     const { id } = useParams<{ id: string }>();
@@ -62,11 +63,11 @@ export default function JewelryItemPage() {
         }
     };
 
-    if (loading) return <main className="p-4">Loading…</main>;
+    if (loading) return <main className="p-4">LoadingÂ…</main>;
     if (error) return <main className="p-4 text-red-600">{error}</main>;
     if (!item) return <main className="p-4">No item found.</main>;
 
-    // Price formatting (always two decimals, “Price: NN.NN USD”)
+    // Price formatting (always two decimals, Â“Price: NN.NN USDÂ”)
     const formattedPrice = item?.price != null ? Number(item.price).toFixed(2) : null;
 
     // Shipping formatting
@@ -76,6 +77,7 @@ export default function JewelryItemPage() {
 
     return (
         <div className="min-h-screen p-8 bg-[#fbfbfa] flex flex-col items-center">
+            <Header />
             {/* Title with subtle effect + underline bar */}
             <h1
                 className="text-3xl font-extrabold tracking-wide mb-3 text-center w-full"


### PR DESCRIPTION
## Summary
- add shared header with EDTArt branding and navigation
- show header on home, catalog, and item pages
- hide link to current page to avoid redundant navigation

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any, no-irregular-whitespace)


------
https://chatgpt.com/codex/tasks/task_e_68bad339b0508325b802563fa433b967