### PR TITLE
style: update header layout and colors

### DIFF
--- a/jewelrysite-frontend/src/components/Header.tsx
+++ b/jewelrysite-frontend/src/components/Header.tsx
@@ -2,7 +2,8 @@ import { Link, useLocation } from "react-router-dom";
 
 export default function Header() {
     const location = useLocation();
-    const BRAND = "#6B8C8E";
+    const BRAND = "#3B82F6"; // brand blue
+    const ACCENT = "#93C5FD"; // light blue accent
 
     const links = [
         { to: "/", label: "Home" },
@@ -12,16 +13,16 @@ export default function Header() {
     const filteredLinks = links.filter(link => link.to !== location.pathname);
 
     return (
-        <header className="flex flex-col items-center mb-8">
+        <header className="w-full flex flex-col items-center bg-blue-50 py-4">
             <h1
-                className="text-3xl font-extrabold tracking-wide text-center"
-                style={{ color: BRAND, textShadow: "0 1px 0 rgba(0,0,0,0.05)" }}
+                className="text-3xl font-extrabold tracking-wide text-center bg-gradient-to-r from-[#3B82F6] to-[#93C5FD] text-transparent bg-clip-text"
+                style={{ textShadow: "0 1px 0 rgba(0,0,0,0.05)" }}
             >
                 EDTArt
             </h1>
             <div
                 className="h-1.5 w-28 rounded-full mt-1"
-                style={{ background: `linear-gradient(90deg, ${BRAND}, ${BRAND}80)` }}
+                style={{ background: `linear-gradient(90deg, ${BRAND}, ${ACCENT})` }}
             />
             <nav className="mt-4 flex gap-4">
                 {filteredLinks.map(link => (

--- a/jewelrysite-frontend/src/pages/CatalogPage.tsx
+++ b/jewelrysite-frontend/src/pages/CatalogPage.tsx
@@ -13,7 +13,7 @@ export default function CatalogPage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    const BRAND = "#6B8C8E";
+    const BRAND = "#3B82F6";
 
     useEffect(() => {
         (async () => {
@@ -26,8 +26,9 @@ export default function CatalogPage() {
                 setItems(catalog);
                 setCategories(cats);
                 setCollections(cols);
-            } catch (e: any) {
-                setError(e?.message ?? "Failed to load catalog");
+            } catch (e: unknown) {
+                const message = e instanceof Error ? e.message : "Failed to load catalog";
+                setError(message);
             } finally {
                 setLoading(false);
             }
@@ -46,53 +47,55 @@ export default function CatalogPage() {
     if (!items.length) return <main className="p-4">No items yet.</main>;
 
     return (
-        <div className="min-h-screen p-6" style={{ backgroundColor: "#fbfbfa" }}>
+        <div className="min-h-screen" style={{ backgroundColor: "#fbfbfa" }}>
             <Header />
-            {/* Header Section */}
-            <div className="mb-8 flex flex-col items-center">
-                <h1
-                    className="text-3xl font-extrabold tracking-wide mb-3 text-center w-full"
-                    style={{ color: BRAND, textShadow: "0 1px 0 rgba(0,0,0,0.05)" }}
-                >
-                    Catalog
-                </h1>
-                <div
-                    className="h-1.5 w-28 rounded-full mb-4"
-                    style={{ background: `linear-gradient(90deg, ${BRAND}, ${BRAND}80)` }}
-                ></div>
-                <div className="flex gap-2 mt-2">
-                    <select
-                        className="select select-bordered"
-                        value={sortType}
-                        onChange={e => {
-                            setSortType(e.target.value as "category" | "collection" | "");
-                            setOption("");
-                        }}
+            <main className="p-6">
+                {/* Header Section */}
+                <div className="mb-8 flex flex-col items-center">
+                    <h1
+                        className="text-3xl font-extrabold tracking-wide mb-3 text-center w-full"
+                        style={{ color: BRAND, textShadow: "0 1px 0 rgba(0,0,0,0.05)" }}
                     >
-                        <option value="">Sort by...</option>
-                        <option value="category">Category</option>
-                        <option value="collection">Collection</option>
-                    </select>
-                    {sortType && (
+                        Catalog
+                    </h1>
+                    <div
+                        className="h-1.5 w-28 rounded-full mb-4"
+                        style={{ background: `linear-gradient(90deg, ${BRAND}, ${BRAND}80)` }}
+                    ></div>
+                    <div className="flex gap-2 mt-2">
                         <select
                             className="select select-bordered"
-                            value={option}
-                            onChange={e => setOption(e.target.value)}
+                            value={sortType}
+                            onChange={e => {
+                                setSortType(e.target.value as "category" | "collection" | "");
+                                setOption("");
+                            }}
                         >
-                            <option value="">Choose {sortType}...</option>
-                            {(sortType === "category" ? categories : collections).map(opt => (
-                                <option key={opt} value={opt}>{opt}</option>
-                            ))}
+                            <option value="">Sort by...</option>
+                            <option value="category">Category</option>
+                            <option value="collection">Collection</option>
                         </select>
-                    )}
+                        {sortType && (
+                            <select
+                                className="select select-bordered"
+                                value={option}
+                                onChange={e => setOption(e.target.value)}
+                            >
+                                <option value="">Choose {sortType}...</option>
+                                {(sortType === "category" ? categories : collections).map(opt => (
+                                    <option key={opt} value={opt}>{opt}</option>
+                                ))}
+                            </select>
+                        )}
+                    </div>
                 </div>
-            </div>
-            {/* Cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4 max-w-6xl mx-auto">
-                {filteredItems.map(item => (
-                    <JewelryCard key={item.id} item={item} />
-                ))}
-            </div>
+                {/* Cards */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4 max-w-6xl mx-auto">
+                    {filteredItems.map(item => (
+                        <JewelryCard key={item.id} item={item} />
+                    ))}
+                </div>
+            </main>
         </div>
     );
 }

--- a/jewelrysite-frontend/src/pages/HomePage.tsx
+++ b/jewelrysite-frontend/src/pages/HomePage.tsx
@@ -2,9 +2,9 @@ import Header from "../components/Header";
 
 export default function HomePage() {
     return (
-        <div className="min-h-screen p-6 bg-[#fbfbfa]">
+        <div className="min-h-screen bg-[#fbfbfa]">
             <Header />
-            <main className="p-6">
+            <main className="p-6 mt-6">
                 <div className="m-4 p-4 rounded-xl bg-blue-600 text-white">
                     Tailwind OK
                 </div>


### PR DESCRIPTION
## Summary
- align header to top at full width and switch to light blue gradient branding
- adjust pages to place header above padded content and use new brand colour
- replace `any` types in item page with explicit interfaces

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/components/Header.tsx src/pages/HomePage.tsx src/pages/CatalogPage.tsx src/pages/JewelryItemPage.tsx && echo "lint ok"`


------
https://chatgpt.com/codex/tasks/task_e_68badd5873388325bc7dc23a526e0ced