### PR TITLE
refactor: use type-only axios imports

### DIFF
--- a/jewelrysite-frontend/src/api/http.ts
+++ b/jewelrysite-frontend/src/api/http.ts
@@ -1,4 +1,5 @@
-import axios, { InternalAxiosRequestConfig } from "axios";
+import axios from "axios";
+import type { InternalAxiosRequestConfig } from "axios";
 import { refreshToken as refreshTokenRequest } from "./auth";
 
 interface RetryConfig extends InternalAxiosRequestConfig {


### PR DESCRIPTION
## Summary
- refactor API client to use type-only axios imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f87f03dc8325bf89fe656603f79e