### PR TITLE
Protect catalog routes with auth guard

### DIFF
--- a/jewelrysite-frontend/src/api/jewelry.ts
+++ b/jewelrysite-frontend/src/api/jewelry.ts
@@ -1,5 +1,6 @@
 import { http } from "./http";
 import type { JewelryItemForCard } from "../types/JewelryItemForCard";
+import type { JewelryItemDetails } from "../types/JewelryItemDetails";
 
 export async function getCatalog(): Promise<JewelryItemForCard[]> {
     const res = await http.get<JewelryItemForCard[]>("/api/jewelryItem");
@@ -17,7 +18,7 @@ export async function getCollections(): Promise<string[]> {
 }
 
 // NEW: Get item details by ID
-export async function getJewelryItemById(id: number): Promise<any> {
-    const res = await http.get(`/api/jewelryItem/${id}`);
+export async function getJewelryItemById(id: number): Promise<JewelryItemDetails> {
+    const res = await http.get<JewelryItemDetails>(`/api/jewelryItem/${id}`);
     return res.data;
 }

--- a/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
+++ b/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
@@ -2,18 +2,11 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState, type CSSProperties } from "react";
 import { getJewelryItemById } from "../api/jewelry";
 import Header from "../components/Header";
+import type { JewelryItemDetails } from "../types/JewelryItemDetails";
 
-interface GalleryImage { url: string }
-interface JewelryItem {
-    name: string;
-    mainImageUrl: string;
-    galleryImages?: GalleryImage[];
-    videoUrl?: string;
-    videoPosterUrl?: string;
-    description: string;
-    price?: number;
-    shippingPrice?: number;
-}
+type CSSPropertiesWithBrand = CSSProperties & {
+    "--brand"?: string;
+};
 
 type Media =
     | { type: "image"; url: string; alt: string }
@@ -21,13 +14,14 @@ type Media =
 
 export default function JewelryItemPage() {
     const { id } = useParams<{ id: string }>();
-    const [item, setItem] = useState<JewelryItem | null>(null);
+    const [item, setItem] = useState<JewelryItemDetails | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
     // Brand/UI
-    const BRAND = "#6B8C8E";       // verdigris you chose
+    const BRAND = "#6B8C8E"; // verdigris you chose
     const MEDIA_H = 520;
+    const brandCssVariables: CSSPropertiesWithBrand = { "--brand": BRAND };
 
     // Gallery state
     const [currentIdx, setCurrentIdx] = useState(0);
@@ -80,7 +74,7 @@ export default function JewelryItemPage() {
         return (
             <>
                 <Header />
-                <main className="p-6">Loading…</main>
+                <main className="p-6">Loadingâ€¦</main>
             </>
         );
     }
@@ -116,7 +110,7 @@ export default function JewelryItemPage() {
                     {/* Card */}
                     <div
                         className="bg-white rounded-lg shadow-lg max-w-5xl w-full p-8"
-                        style={{ "--brand": BRAND } as CSSProperties}
+                        style={brandCssVariables}
                     >
                         {/* Top section: thumbnails + main media */}
                         <div className="w-full flex flex-row gap-8">
@@ -131,7 +125,7 @@ export default function JewelryItemPage() {
                                             onClick={() => setCurrentIdx(idx)}
                                             className={`relative w-16 h-16 rounded-lg border cursor-pointer transition ring-2 ${isActive ? "ring-[var(--brand)]" : "ring-transparent"
                                                 } bg-white overflow-hidden`}
-                                            style={{ ["--brand" as any]: BRAND }}
+                                            style={brandCssVariables}
                                             title={media.alt || `Gallery ${idx + 1}`}
                                         >
                                             {media.type === "image" ? (

--- a/jewelrysite-frontend/src/routes/AppRouter.tsx
+++ b/jewelrysite-frontend/src/routes/AppRouter.tsx
@@ -1,17 +1,47 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import HomePage from "../pages/HomePage";
 import CatalogPage from "../pages/CatalogPage";
 import JewelryItemPage from "../pages/JewelryItemPage";
 import LoginPage from "../pages/LoginPage";
 import RegisterPage from "../pages/RegisterPage";
+import { useAuth } from "../context/AuthContext";
+
+function RequireAuth({ children }: { children: JSX.Element }) {
+    const { jwtToken } = useAuth();
+    const location = useLocation();
+
+    const storedToken = typeof window !== "undefined" ? localStorage.getItem("jwtToken") : null;
+    const token = jwtToken ?? storedToken;
+
+    if (!token) {
+        const from = `${location.pathname}${location.search}${location.hash}`;
+        return <Navigate to="/login" state={{ from }} replace />;
+    }
+
+    return children;
+}
 
 export default function AppRouter() {
     return (
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<HomePage />} />
-                <Route path="/catalog" element={<CatalogPage />} />
-                <Route path="/item/:id" element={<JewelryItemPage />} />
+                <Route
+                    path="/catalog"
+                    element={
+                        <RequireAuth>
+                            <CatalogPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/item/:id"
+                    element={
+                        <RequireAuth>
+                            <JewelryItemPage />
+                        </RequireAuth>
+                    }
+                />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<RegisterPage />} />
             </Routes>

--- a/jewelrysite-frontend/src/types/JewelryItemDetails.ts
+++ b/jewelrysite-frontend/src/types/JewelryItemDetails.ts
@@ -1,0 +1,15 @@
+export interface JewelryItemGalleryImage {
+    url: string;
+}
+
+export interface JewelryItemDetails {
+    id?: number;
+    name: string;
+    mainImageUrl: string;
+    galleryImages?: JewelryItemGalleryImage[];
+    videoUrl?: string;
+    videoPosterUrl?: string;
+    description: string;
+    price?: number;
+    shippingPrice?: number;
+}


### PR DESCRIPTION
## Summary
- wrap catalog- and item-level routes in a RequireAuth component that checks AuthContext and redirects to login when unauthenticated
- ensure the login and registration pages are routed through AppRouter
- add a strongly typed jewelry item details model that removes lingering any casts on the item page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95dd223508325944a5f202051665e