### PR TITLE
Update header with auth-aware navigation

### DIFF
--- a/jewelrysite-frontend/src/components/Header.tsx
+++ b/jewelrysite-frontend/src/components/Header.tsx
@@ -1,16 +1,34 @@
 import { Link, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 export default function Header() {
     const location = useLocation();
+    const { user, logout } = useAuth();
     const BRAND = "#6B8C8E";     // same as your page titles
     const HEADER_BG = "#E3F0F2";
 
+    const isAuthenticated = Boolean(user);
     const links = [
         { to: "/", label: "Home" },
         { to: "/catalog", label: "Catalog" },
-        { to: "/login", label: "Login" },
+        ...(!isAuthenticated
+            ? [
+                  { to: "/login", label: "Login" },
+                  { to: "/register", label: "Register" },
+              ]
+            : []),
     ];
     const filteredLinks = links.filter(l => l.to !== location.pathname);
+    const displayName =
+        (user?.username as string | undefined) ??
+        (user?.name as string | undefined) ??
+        (user?.email as string | undefined) ??
+        (typeof user?.sub === "string"
+            ? user?.sub
+            : user?.sub !== undefined
+                ? String(user.sub)
+                : undefined) ??
+        "Account";
 
     return (
         <header
@@ -46,28 +64,49 @@ export default function Header() {
                     ))}
                 </nav>
 
-                {/* Cart icon at far right */}
-                <Link
-                    to="/cart"
-                    aria-label="Cart"
-                    className="ml-auto inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-[rgba(0,0,0,0.06)]"
-                    title="Cart"
-                >
-                    <svg
-                        width="22" height="22" viewBox="0 0 24 24" fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
+                <div className="ml-auto flex items-center gap-4">
+                    {isAuthenticated && (
+                        <>
+                            <span
+                                className="text-sm sm:text-base font-semibold"
+                                style={{ color: BRAND }}
+                            >
+                                {displayName}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={logout}
+                                className="text-sm sm:text-base font-semibold hover:underline"
+                                style={{ color: BRAND }}
+                            >
+                                Logout
+                            </button>
+                        </>
+                    )}
+
+                    {/* Cart icon at far right */}
+                    <Link
+                        to="/cart"
+                        aria-label="Cart"
+                        className="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-[rgba(0,0,0,0.06)]"
+                        title="Cart"
                     >
-                        <path
-                            d="M6 6h15l-1.5 8.5a2 2 0 0 1-2 1.5H9a2 2 0 0 1-2-1.5L5 3H2"
-                            stroke={BRAND}
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                        <circle cx="9" cy="20" r="1.5" fill={BRAND} />
-                        <circle cx="17" cy="20" r="1.5" fill={BRAND} />
-                    </svg>
-                </Link>
+                        <svg
+                            width="22" height="22" viewBox="0 0 24 24" fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M6 6h15l-1.5 8.5a2 2 0 0 1-2 1.5H9a2 2 0 0 1-2-1.5L5 3H2"
+                                stroke={BRAND}
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <circle cx="9" cy="20" r="1.5" fill={BRAND} />
+                            <circle cx="17" cy="20" r="1.5" fill={BRAND} />
+                        </svg>
+                    </Link>
+                </div>
             </div>
         </header>
     );


### PR DESCRIPTION
## Summary
- update the header component to consume `AuthContext` and react to authentication state
- show login/register links when signed out and the username plus logout action when signed in

## Testing
- npm run lint *(fails: pre-existing `@typescript-eslint/no-explicit-any` errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c960e7022c8325a27cb6869c9e4e89