### PR TITLE
Remove register link from guest navigation

### DIFF
--- a/jewelrysite-frontend/src/components/Header.tsx
+++ b/jewelrysite-frontend/src/components/Header.tsx
@@ -14,7 +14,6 @@ export default function Header() {
         ...(!isAuthenticated
             ? [
                   { to: "/login", label: "Login" },
-                  { to: "/register", label: "Register" },
               ]
             : []),
     ];


### PR DESCRIPTION
## Summary
- remove the register link from the header guest navigation so only the login option appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9640f3e4483259575975fe10219d6