### PR TITLE
Decode JWT claims for header display

### DIFF
--- a/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
+++ b/jewelrysite-frontend/src/pages/JewelryItemPage.tsx
@@ -49,12 +49,12 @@ export default function JewelryItemPage() {
     // Build gallery once item loads
     const gallery: Media[] = item
         ? [
-            { type: "image", url: item.mainImageUrl, alt: item.name },
+            { type: "image" as const, url: item.mainImageUrl, alt: item.name },
             ...(item.galleryImages ?? [])
                 .filter(img => img.url && img.url !== item.mainImageUrl)
-                .map(img => ({ type: "image", url: img.url, alt: item.name })),
+                .map(img => ({ type: "image" as const, url: img.url, alt: item.name })),
             ...(item.videoUrl
-                ? [{ type: "video", url: item.videoUrl, alt: "Video", poster: item.videoPosterUrl }]
+                ? [{ type: "video" as const, url: item.videoUrl, alt: "Video", poster: item.videoPosterUrl }]
                 : []),
         ]
         : [];
@@ -80,7 +80,7 @@ export default function JewelryItemPage() {
         return (
             <>
                 <Header />
-                <main className="p-6">Loading…</main>
+                <main className="p-6">Loadingâ€¦</main>
             </>
         );
     }

--- a/jewelrysite-frontend/src/utils/jwt.ts
+++ b/jewelrysite-frontend/src/utils/jwt.ts
@@ -1,0 +1,23 @@
+export type JwtPayload = {
+    [key: string]: unknown;
+};
+
+export function decodeJwtPayload<T extends JwtPayload = JwtPayload>(token: string): T | null {
+    try {
+        const parts = token.split(".");
+        if (parts.length < 2) {
+            return null;
+        }
+        const base64Url = parts[1];
+        const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+        const jsonPayload = decodeURIComponent(
+            atob(base64)
+                .split("")
+                .map(char => "%" + ("00" + char.charCodeAt(0).toString(16)).slice(-2))
+                .join("")
+        );
+        return JSON.parse(jsonPayload) as T;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared JWT decoding helper and reuse it across the auth context
- update the header to derive the greeting from decoded token claims, preferring name-like fields
- fix gallery media typings so the production build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9686d28d4832582aa1ff6d9a894d5