### PR TITLE
Fix add-to-cart auth handling and empty cart feedback

### DIFF
--- a/jewelrysite-frontend/src/pages/CartPage.tsx
+++ b/jewelrysite-frontend/src/pages/CartPage.tsx
@@ -156,10 +156,15 @@ export default function CartPage() {
                             {error}
                         </div>
                     ) : items.length === 0 ? (
-                        <div className="bg-white shadow rounded-lg p-10 text-center">
+                        <div
+                            className="bg-white shadow rounded-lg p-10 text-center"
+                            role="status"
+                            aria-live="polite"
+                        >
                             <p className="text-lg font-semibold text-gray-700">Your cart is currently empty.</p>
                             <p className="text-sm text-gray-500 mt-2">
-                                Browse our catalog to discover handcrafted jewelry that fits your style.
+                                Items you add will appear here. Browse our catalog to discover handcrafted jewelry that fits your
+                                style.
                             </p>
                             <Link
                                 to="/catalog"

--- a/jewelrysite-frontend/src/utils/user.ts
+++ b/jewelrysite-frontend/src/utils/user.ts
@@ -15,14 +15,24 @@ function parseUserId(candidate: unknown): number | null {
     return null;
 }
 
+const POSSIBLE_ID_KEYS = new Set<string>([
+    "userid",
+    "id",
+    "sub",
+    "nameid",
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+]);
+
 function extractFromClaims(claims: UserLike): number | null {
     if (!claims) {
         return null;
     }
     const record = claims as Record<string, unknown>;
-    const possibleKeys = ["userId", "id", "sub"] as const;
-    for (const key of possibleKeys) {
-        const value = record[key];
+    for (const [key, value] of Object.entries(record)) {
+        const normalizedKey = key.toLowerCase();
+        if (!POSSIBLE_ID_KEYS.has(normalizedKey) && !POSSIBLE_ID_KEYS.has(key)) {
+            continue;
+        }
         const parsed = parseUserId(value);
         if (parsed !== null) {
             return parsed;


### PR DESCRIPTION
## Summary
- ensure the front-end resolves the authenticated user ID from JWT name identifier claims so add-to-cart keeps working while logged in
- propagate the resolved user ID through auth state and refresh flows to keep API calls authorized
- make the empty cart state explicitly inform shoppers with an accessible status message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8726ae008325aeab4a5c003aa985