### PR TITLE
Make cart item image background match card surface

### DIFF
--- a/jewelrysite-frontend/src/pages/CartPage.tsx
+++ b/jewelrysite-frontend/src/pages/CartPage.tsx
@@ -187,7 +187,7 @@ export default function CartPage() {
                                             className="bg-white shadow rounded-xl overflow-hidden border border-gray-100"
                                         >
                                             <div className="flex flex-col sm:flex-row">
-                                                <div className="sm:w-44 sm:h-44 w-full h-56 bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center overflow-hidden">
+                                                <div className="sm:w-44 sm:h-44 w-full h-56 bg-white flex items-center justify-center overflow-hidden">
                                                     {jewelry?.mainImageUrl ? (
                                                         <img
                                                             src={jewelry.mainImageUrl}


### PR DESCRIPTION
## Summary
- replace the gray gradient behind cart item images with a plain white background so the image area matches the surrounding card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca90e29f98832591df3034effca112