### PR TITLE
Add admin control panel route and header link

### DIFF
--- a/jewelrysite-frontend/src/components/Header.tsx
+++ b/jewelrysite-frontend/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { decodeJwtPayload } from "../utils/jwt";
+import { extractRoles } from "../utils/roles";
 
 type Claims = {
     sub?: string | number;
@@ -27,6 +28,12 @@ export default function Header() {
     }, [jwtToken, user]);
 
     const isAuthenticated = Boolean(claims);
+    const roles = useMemo(() => extractRoles(claims), [claims]);
+    const isAdmin = useMemo(
+        () => roles.some(role => role.toLowerCase() === "admin"),
+        [roles]
+    );
+
     const links = [
         { to: "/", label: "Home" },
         { to: "/catalog", label: "Catalog" },
@@ -166,6 +173,37 @@ export default function Header() {
                     </nav>
 
                     <div className="ml-auto flex items-center gap-4">
+                        {isAdmin && (
+                            <Link
+                                to="/control-panel"
+                                aria-label="Admin control panel"
+                                className="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-[rgba(0,0,0,0.06)]"
+                                title="Control Panel"
+                            >
+                                <svg
+                                    width="22"
+                                    height="22"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="M12 15.5A3.5 3.5 0 1 0 12 8.5a3.5 3.5 0 0 0 0 7z"
+                                        stroke={BRAND}
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                    />
+                                    <path
+                                        d="M19.4 13a7.05 7.05 0 0 0 .06-2l2.04-1.16-2-3.46-2.36.62a6.99 6.99 0 0 0-1.74-1L15 3h-6l-.4 2.01c-.61.25-1.19.59-1.74 1l-2.36-.62-2 3.46L4.54 11a6.95 6.95 0 0 0 0 2l-2.04 1.16 2 3.46 2.36-.62c.55.41 1.13.75 1.74 1L9 21h6l.4-2.01c.61-.25 1.19-.59 1.74-1l2.36.62 2-3.46L19.4 13z"
+                                        stroke={BRAND}
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                    />
+                                </svg>
+                            </Link>
+                        )}
                         {isAuthenticated && (
                             <>
                                 <span

--- a/jewelrysite-frontend/src/pages/ControlPanelPage.tsx
+++ b/jewelrysite-frontend/src/pages/ControlPanelPage.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { decodeJwtPayload } from "../utils/jwt";
+import { extractRoles } from "../utils/roles";
+
+type Claims = {
+    [key: string]: unknown;
+};
+
+export default function ControlPanelPage() {
+    const { user, jwtToken } = useAuth();
+
+    const claims = useMemo<Claims | null>(() => {
+        if (user) {
+            return user as Claims;
+        }
+        if (jwtToken) {
+            return decodeJwtPayload<Claims>(jwtToken);
+        }
+        return null;
+    }, [jwtToken, user]);
+
+    const roles = useMemo(() => extractRoles(claims), [claims]);
+    const isAdmin = roles.some(role => role.toLowerCase() === "admin");
+
+    if (!isAdmin) {
+        return (
+            <main className="p-6">
+                <h1 className="text-2xl font-bold mb-4">Control Panel</h1>
+                <p>You do not have permission to view this page.</p>
+                <p className="mt-4">
+                    <Link to="/" className="text-blue-600 underline">
+                        Return to the home page
+                    </Link>
+                </p>
+            </main>
+        );
+    }
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-bold mb-4">Control Panel</h1>
+            <p>Admin-only controls will appear here.</p>
+        </main>
+    );
+}

--- a/jewelrysite-frontend/src/routes/AppRouter.tsx
+++ b/jewelrysite-frontend/src/routes/AppRouter.tsx
@@ -5,6 +5,7 @@ import JewelryItemPage from "../pages/JewelryItemPage";
 import LoginPage from "../pages/LoginPage";
 import RegisterPage from "../pages/RegisterPage";
 import CartPage from "../pages/CartPage";
+import ControlPanelPage from "../pages/ControlPanelPage";
 
 export default function AppRouter() {
     return (
@@ -16,6 +17,7 @@ export default function AppRouter() {
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<RegisterPage />} />
                 <Route path="/cart" element={<CartPage />} />
+                <Route path="/control-panel" element={<ControlPanelPage />} />
             </Routes>
         </BrowserRouter>
     );

--- a/jewelrysite-frontend/src/utils/roles.ts
+++ b/jewelrysite-frontend/src/utils/roles.ts
@@ -1,0 +1,47 @@
+export function extractRoles(claims: Record<string, unknown> | null | undefined): string[] {
+    if (!claims) {
+        return [];
+    }
+
+    const roleSet = new Set<string>();
+
+    const isRoleKey = (key: string) => {
+        const normalized = key.toLowerCase();
+        if (normalized === "role" || normalized === "roles") {
+            return true;
+        }
+        const suffixes = ["/role", ":role", "_role", "/roles", ":roles", "_roles"];
+        return suffixes.some(suffix => normalized.endsWith(suffix));
+    };
+
+    const addValue = (value: unknown) => {
+        if (typeof value === "string") {
+            value
+                .split(/[,;]/)
+                .map(segment => segment.trim())
+                .filter(Boolean)
+                .forEach(segment => roleSet.add(segment));
+            return;
+        }
+        if (Array.isArray(value)) {
+            value.forEach(entry => {
+                if (typeof entry === "string" && entry.trim().length > 0) {
+                    roleSet.add(entry.trim());
+                }
+            });
+        }
+    };
+
+    Object.entries(claims).forEach(([key, value]) => {
+        if (!isRoleKey(key)) {
+            return;
+        }
+        addValue(value);
+    });
+
+    return Array.from(roleSet);
+}
+
+export function isAdmin(claims: Record<string, unknown> | null | undefined): boolean {
+    return extractRoles(claims).some(role => role.toLowerCase() === "admin");
+}


### PR DESCRIPTION
## Summary
- add a placeholder control panel page with a simple admin-only guard
- expose a reusable role extraction helper and use it in the header to detect admins
- link admins to the control panel from the header and register the new route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25c80617483259a44f1a968013af6