### PR TITLE
Restrict cart access to authenticated user

### DIFF
--- a/JewelrySite/Controllers/CartController.cs
+++ b/JewelrySite/Controllers/CartController.cs
@@ -3,6 +3,7 @@ using JewelrySite.DAL;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace JewelrySite.Controllers
 {
@@ -19,32 +20,72 @@ namespace JewelrySite.Controllers
 			_cartService = cartService;
 		}
 
-		[HttpGet]
-		public async Task<ActionResult<Cart>> GetCartItems(int id)
-		{
-			try
-			{
-				Cart cart = await _cartService.GetOrCreateCartByUserId(id);
-				return cart;
-			}
-			catch (InvalidOperationException)
-			{
-				return NotFound("no such user exists");
-			}
-		
-		}
+                private bool TryResolveAuthorizedUserId(int? requestedUserId, out int userId, out ActionResult? errorResult)
+                {
+                        errorResult = null;
+                        userId = 0;
 
-		[HttpPost]
-		public async Task<ActionResult<Cart>> AddItemToCart(int userId, int jewelryItemId, int qty)
-		{
-			try
-			{
-				Cart cart = await _cartService.AddItemToCart(userId, jewelryItemId, qty);
-				return CreatedAtAction(nameof(AddItemToCart),cart.Items.Where(i=> i.Id == jewelryItemId));
-			}
-			catch (ArgumentOutOfRangeException)
-			{
-				return BadRequest("quantity of an item cannot be a negetive value");
+                        string? userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                        if (!int.TryParse(userIdClaim, out int authenticatedUserId))
+                        {
+                                errorResult = Unauthorized();
+                                return false;
+                        }
+
+                        bool isAdmin = User.IsInRole("Admin");
+
+                        if (requestedUserId.HasValue)
+                        {
+                                if (!isAdmin && requestedUserId.Value != authenticatedUserId)
+                                {
+                                        errorResult = Forbid();
+                                        return false;
+                                }
+
+                                userId = requestedUserId.Value;
+                                return true;
+                        }
+
+                        userId = authenticatedUserId;
+                        return true;
+                }
+
+                [HttpGet]
+                public async Task<ActionResult<Cart>> GetCartItems(int? id)
+                {
+                        if (!TryResolveAuthorizedUserId(id, out int userId, out ActionResult? error))
+                        {
+                                return error!;
+                        }
+
+                        try
+                        {
+                                Cart cart = await _cartService.GetOrCreateCartByUserId(userId);
+                                return cart;
+                        }
+                        catch (InvalidOperationException)
+                        {
+                                return NotFound("no such user exists");
+                        }
+
+                }
+
+                [HttpPost]
+                public async Task<ActionResult<Cart>> AddItemToCart(int? userId, int jewelryItemId, int qty)
+                {
+                        if (!TryResolveAuthorizedUserId(userId, out int resolvedUserId, out ActionResult? error))
+                        {
+                                return error!;
+                        }
+
+                        try
+                        {
+                                Cart cart = await _cartService.AddItemToCart(resolvedUserId, jewelryItemId, qty);
+                                return CreatedAtAction(nameof(AddItemToCart),cart.Items.Where(i=> i.Id == jewelryItemId));
+                        }
+                        catch (ArgumentOutOfRangeException)
+                        {
+                                return BadRequest("quantity of an item cannot be a negetive value");
 			}
 			catch (InvalidOperationException)
 			{
@@ -52,17 +93,22 @@ namespace JewelrySite.Controllers
 			}
 		}
 
-		[HttpDelete]
-		public async Task<ActionResult<Cart>> RemoveItemFromCart(int userId, int jewelryItemId)
-		{
-			try
-			{
-				Cart cart = await _cartService.RemoveItemAsync(userId, jewelryItemId);
-				return Ok("resource deleted successfully");
-			}
-			catch (InvalidOperationException)
-			{
-				return BadRequest("no such user or jewlry item exists");
+                [HttpDelete]
+                public async Task<ActionResult<Cart>> RemoveItemFromCart(int? userId, int jewelryItemId)
+                {
+                        if (!TryResolveAuthorizedUserId(userId, out int resolvedUserId, out ActionResult? error))
+                        {
+                                return error!;
+                        }
+
+                        try
+                        {
+                                Cart cart = await _cartService.RemoveItemAsync(resolvedUserId, jewelryItemId);
+                                return Ok("resource deleted successfully");
+                        }
+                        catch (InvalidOperationException)
+                        {
+                                return BadRequest("no such user or jewlry item exists");
 			}
 		}
 


### PR DESCRIPTION
## Summary
- ensure cart endpoints resolve the calling user's id from JWT claims
- add helper to authorize requested user ids and block non-admins from accessing other carts

## Testing
- attempted `dotnet build JewelrySite/JewelrySite.csproj` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d260ba19bc8325bbfed79c75c3f2ea