### PR TITLE
Load gallery assets when editing control panel items

### DIFF
--- a/JewelrySite/Controllers/JewelryItemController.cs
+++ b/JewelrySite/Controllers/JewelryItemController.cs
@@ -25,13 +25,13 @@ namespace JewelrySite.Controllers
 			return Ok(items);
 		}
 
-		[HttpGet("{id}")] 
-		public async Task<ActionResult<JewelryItem>> GetJewerlyById(int id) 
-		{
-			JewelryItem j = await _service.GetJewelryItemById(id);
-			if (j == null) {return NotFound();}
-			return Ok(j);
-		}
+                [HttpGet("{id}")]
+                public async Task<ActionResult<JewelryItemDetailDto>> GetJewerlyById(int id)
+                {
+                        JewelryItemDetailDto j = await _service.GetJewelryItemById(id);
+                        if (j == null) { return NotFound(); }
+                        return Ok(j);
+                }
 
 		[HttpPost]
 		public async Task<ActionResult<JewelryItem>> AddJewerlyItem(JewelryItem j)

--- a/JewelrySite/DAL/JewelryItemService.cs
+++ b/JewelrySite/DAL/JewelryItemService.cs
@@ -1,6 +1,8 @@
-﻿using JewelrySite.BL;
+using JewelrySite.BL;
 using JewelrySite.DTO;
 using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace JewelrySite.DAL
@@ -39,13 +41,50 @@ namespace JewelrySite.DAL
 
 		}
 
-		public async Task<JewelryItem> GetJewelryItemById(int id)
-		{
-			return await _db.JewelryItems
-			.AsNoTracking()                       
-			.Include(j => j.GalleryImages)       
-			.FirstOrDefaultAsync(j => j.Id == id);
-		}
+               public async Task<JewelryItemDetailDto?> GetJewelryItemById(int id)
+               {
+                       JewelryItem item = await _db.JewelryItems
+                               .AsNoTracking()
+                               .Include(j => j.GalleryImages)
+                               .FirstOrDefaultAsync(j => j.Id == id);
+
+                       if (item is null)
+                       {
+                               return null;
+                       }
+
+                       List<JewelryImageDetailDto> gallery = item.GalleryImages?
+                               .OrderBy(g => g.SortOrder)
+                               .Select(g => new JewelryImageDetailDto
+                               {
+                                       Id = g.Id,
+                                       JewelryItemId = g.JewelryItemId,
+                                       Url = g.Url,
+                                       SortOrder = g.SortOrder
+                               })
+                               .ToList() ?? new List<JewelryImageDetailDto>();
+
+                       return new JewelryItemDetailDto
+                       {
+                               Id = item.Id,
+                               Name = item.Name,
+                               Description = item.Description,
+                               Category = item.Category,
+                               Collection = item.Collection,
+                               WeightGrams = item.WeightGrams,
+                               Color = item.Color,
+                               SizeCM = item.SizeCM,
+                               Price = item.Price,
+                               StockQuantity = item.StockQuantity,
+                               IsAvailable = item.IsAvailable,
+                               MainImageUrl = item.MainImageUrl,
+                               ShippingPrice = item.ShippingPrice,
+                               VideoUrl = item.VideoUrl,
+                               VideoPosterUrl = item.VideoPosterUrl,
+                               VideoDurationSeconds = item.VideoDurationSeconds,
+                               GalleryImages = gallery
+                       };
+               }
 		
 		public async Task<JewelryItem> AddJewelryItem(JewelryItem jewelryItem)
 		{

--- a/JewelrySite/DTO/JewelryDTO.cs
+++ b/JewelrySite/DTO/JewelryDTO.cs
@@ -1,17 +1,48 @@
-﻿namespace JewelrySite.DTO
+using System.Collections.Generic;
+
+namespace JewelrySite.DTO
 {
-	public record JewelryItemCatalogDto(
-		int Id,
-		string Name,
-		string? Description,
-		string Category,
-		string Collection,
-		decimal? Price,
-		int? StockQuantity,
-		bool? IsAvailable,
-		string MainImageUrl,
-		string? Color,
-		string? SizeCM,
-		decimal? ShippingPrice
-	);
+    public record JewelryItemCatalogDto(
+        int Id,
+        string Name,
+        string? Description,
+        string Category,
+        string Collection,
+        decimal? Price,
+        int? StockQuantity,
+        bool? IsAvailable,
+        string MainImageUrl,
+        string? Color,
+        string? SizeCM,
+        decimal? ShippingPrice
+    );
+
+    public class JewelryImageDetailDto
+    {
+        public int Id { get; init; }
+        public int JewelryItemId { get; init; }
+        public string Url { get; init; } = string.Empty;
+        public int SortOrder { get; init; }
+    }
+
+    public class JewelryItemDetailDto
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Description { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string? Collection { get; init; }
+        public decimal? WeightGrams { get; init; }
+        public string? Color { get; init; }
+        public string? SizeCM { get; init; }
+        public decimal? Price { get; init; }
+        public int? StockQuantity { get; init; }
+        public bool? IsAvailable { get; init; }
+        public string? MainImageUrl { get; init; }
+        public decimal ShippingPrice { get; init; }
+        public string? VideoUrl { get; init; }
+        public string? VideoPosterUrl { get; init; }
+        public int? VideoDurationSeconds { get; init; }
+        public List<JewelryImageDetailDto> GalleryImages { get; init; } = new();
+    }
 }


### PR DESCRIPTION
## Summary
- expose a detailed DTO so the jewelry item by id endpoint returns gallery image metadata
- update the control panel modify workflow to fetch the detail payload with guards, show image previews, and support canceling edits
- ensure gallery URLs are sorted and surfaced in the admin form with inline previews

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2784b6dec83258ed07d5cd555b94e