### PR TITLE
Add password policy validation and reset password flows

### DIFF
--- a/JewelrySite/Controllers/AuthController.cs
+++ b/JewelrySite/Controllers/AuthController.cs
@@ -23,13 +23,20 @@ namespace JewelrySite.Controllers
 
 		public static User user = new User();
 
-		[HttpPost("register")]
-		public async Task<ActionResult<User>> register(UserDto request)
-		{
-			User user = await _service.RegisterAsync(request);
-			if (user == null) { return BadRequest("Such user already exists");}
-			return Ok(user);
-		}
+                [HttpPost("register")]
+                public async Task<ActionResult<User>> register(UserDto request)
+                {
+                        try
+                        {
+                                User user = await _service.RegisterAsync(request);
+                                if (user == null) { return BadRequest("Such user already exists"); }
+                                return Ok(user);
+                        }
+                        catch (InvalidOperationException ex)
+                        {
+                                return BadRequest(ex.Message);
+                        }
+                }
 
                 [HttpPost("login")]
                 public async Task<ActionResult<LoginResponseDto>> Login(LoginDto request)

--- a/JewelrySite/DAL/AuthService.cs
+++ b/JewelrySite/DAL/AuthService.cs
@@ -56,13 +56,18 @@ namespace JewelrySite.DAL
 		}
 
 
-		public async Task<User?> RegisterAsync(UserDto request)
-		{
-			if (await _db.Users.AnyAsync(u => u.Username == request.Username)) {
-				return null; //cannot register with that name  since we have someone with that name 
-			}
-			
-			User user = new User();
+                public async Task<User?> RegisterAsync(UserDto request)
+                {
+                        if (!PasswordPolicy.IsValid(request.Password))
+                        {
+                                throw new InvalidOperationException("Password must be at least 8 characters long and include at least one digit.");
+                        }
+
+                        if (await _db.Users.AnyAsync(u => u.Username == request.Username)) {
+                                return null; //cannot register with that name  since we have someone with that name
+                        }
+
+                        User user = new User();
 			
 			string hashedPassword = new PasswordHasher<User>()
 				.HashPassword(user, request.Password);

--- a/jewelrysite-frontend/src/api/auth.ts
+++ b/jewelrysite-frontend/src/api/auth.ts
@@ -22,3 +22,29 @@ export async function refreshToken(
     const res = await http.post<AuthResponse>("/api/Auth/refresh-token", data);
     return res.data;
 }
+
+export async function forgotPassword(email: string): Promise<string> {
+    const res = await http.post<{ message: string }>(
+        "/api/Auth/forgot-password",
+        JSON.stringify(email.trim()),
+        {
+            headers: { "Content-Type": "application/json" },
+        }
+    );
+    return res.data.message;
+}
+
+export async function resetPassword(data: {
+    token: string;
+    newPassword: string;
+}): Promise<string> {
+    const params = new URLSearchParams({
+        token: data.token,
+        newPassword: data.newPassword,
+    });
+
+    const res = await http.post<{ message: string }>(
+        `/api/Auth/reset-password?${params.toString()}`
+    );
+    return res.data.message;
+}

--- a/jewelrysite-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/jewelrysite-frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { isAxiosError } from "axios";
+import { Link } from "react-router-dom";
+import Header from "../components/Header";
+import { forgotPassword } from "../api/auth";
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("");
+    const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(
+        null
+    );
+    const [submitting, setSubmitting] = useState(false);
+
+    const onSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setStatus(null);
+        setSubmitting(true);
+        try {
+            const message = await forgotPassword(email);
+            setStatus({ type: "success", message });
+        } catch (error) {
+            if (isAxiosError(error)) {
+                const serverMessage =
+                    (typeof error.response?.data === "string"
+                        ? error.response.data
+                        : error.response?.data?.message) ||
+                    error.message;
+                setStatus({ type: "error", message: serverMessage });
+            } else {
+                const message = error instanceof Error ? error.message : "Request failed";
+                setStatus({ type: "error", message });
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-[#f3f6f7] via-[#eef3f4] to-[#6B8C8E] bg-fixed flex flex-col">
+            <Header />
+            <main className="flex-grow flex items-center justify-center p-4">
+                <form
+                    onSubmit={onSubmit}
+                    className="bg-white/90 rounded-lg shadow-md p-6 w-full max-w-md space-y-4"
+                >
+                    <h1 className="text-2xl font-bold text-center" style={{ color: "#6B8C8E" }}>
+                        Forgot Password
+                    </h1>
+                    <p className="text-sm text-gray-600 text-center">
+                        Enter your email address and we’ll send you a link to reset your EDTArt password.
+                    </p>
+                    {status && (
+                        <div
+                            className={`text-sm rounded-md px-3 py-2 ${
+                                status.type === "success"
+                                    ? "bg-green-50 text-green-700"
+                                    : "bg-red-50 text-red-700"
+                            }`}
+                        >
+                            {status.message}
+                        </div>
+                    )}
+                    <div className="form-control">
+                        <label className="label">
+                            <span className="label-text">Email</span>
+                        </label>
+                        <input
+                            type="email"
+                            className="input input-bordered w-full"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            required
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        className="btn w-full text-white"
+                        style={{ backgroundColor: "#6B8C8E" }}
+                        disabled={submitting}
+                    >
+                        {submitting ? "Sending..." : "Send reset link"}
+                    </button>
+                    <p className="text-sm text-center">
+                        Remembered it?{" "}
+                        <Link to="/login" className="underline">
+                            Back to login
+                        </Link>
+                    </p>
+                </form>
+            </main>
+        </div>
+    );
+}

--- a/jewelrysite-frontend/src/pages/LoginPage.tsx
+++ b/jewelrysite-frontend/src/pages/LoginPage.tsx
@@ -57,6 +57,11 @@ export default function LoginPage() {
                             required
                         />
                     </div>
+                    <div className="text-right">
+                        <Link to="/forgot-password" className="text-sm text-[#6B8C8E] hover:underline">
+                            Forgot your password?
+                        </Link>
+                    </div>
                     <button
                         type="submit"
                         className="btn w-full text-white"

--- a/jewelrysite-frontend/src/pages/ResetPasswordPage.tsx
+++ b/jewelrysite-frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from "react";
+import { isAxiosError } from "axios";
+import { Link, useSearchParams } from "react-router-dom";
+import Header from "../components/Header";
+import { resetPassword } from "../api/auth";
+import { validatePassword } from "../utils/passwordPolicy";
+
+export default function ResetPasswordPage() {
+    const [params] = useSearchParams();
+    const token = useMemo(() => params.get("token") ?? "", [params]);
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
+    const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(
+        null
+    );
+    const [submitting, setSubmitting] = useState(false);
+
+    const disabled = !token;
+
+    const onSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (disabled) return;
+
+        setStatus(null);
+        const validationErrors = validatePassword(newPassword);
+        setPasswordErrors(validationErrors);
+        if (validationErrors.length > 0) {
+            setStatus({ type: "error", message: "Please choose a password that meets the requirements." });
+            return;
+        }
+
+        if (newPassword !== confirmPassword) {
+            setStatus({ type: "error", message: "Passwords do not match." });
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            const message = await resetPassword({ token, newPassword });
+            setStatus({ type: "success", message });
+            setNewPassword("");
+            setConfirmPassword("");
+        } catch (error) {
+            if (isAxiosError(error)) {
+                const serverMessage =
+                    (typeof error.response?.data === "string"
+                        ? error.response.data
+                        : error.response?.data?.message) ||
+                    error.message;
+                setStatus({ type: "error", message: serverMessage });
+            } else {
+                const message = error instanceof Error ? error.message : "Request failed";
+                setStatus({ type: "error", message });
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-[#f3f6f7] via-[#eef3f4] to-[#6B8C8E] bg-fixed flex flex-col">
+            <Header />
+            <main className="flex-grow flex items-center justify-center p-4">
+                <form
+                    onSubmit={onSubmit}
+                    className="bg-white/90 rounded-lg shadow-md p-6 w-full max-w-md space-y-4"
+                >
+                    <h1 className="text-2xl font-bold text-center" style={{ color: "#6B8C8E" }}>
+                        Reset Password
+                    </h1>
+                    {!token && (
+                        <div className="text-sm bg-red-50 text-red-700 px-3 py-2 rounded-md">
+                            The reset link is missing or invalid. Please request a new one.
+                        </div>
+                    )}
+                    <p className="text-sm text-gray-600 text-center">
+                        Choose a new password for your EDTArt account. Make sure it’s something secure.
+                    </p>
+                    {status && (
+                        <div
+                            className={`text-sm rounded-md px-3 py-2 ${
+                                status.type === "success"
+                                    ? "bg-green-50 text-green-700"
+                                    : "bg-red-50 text-red-700"
+                            }`}
+                        >
+                            {status.message}
+                        </div>
+                    )}
+                    <div className="form-control">
+                        <label className="label">
+                            <span className="label-text">New password</span>
+                        </label>
+                        <input
+                            type="password"
+                            className="input input-bordered w-full"
+                            value={newPassword}
+                            onChange={(e) => {
+                                const value = e.target.value;
+                                setNewPassword(value);
+                                setPasswordErrors(validatePassword(value));
+                            }}
+                            required
+                            disabled={disabled}
+                        />
+                        <p className="text-xs text-gray-500 mt-1">
+                            Use at least 8 characters and include a number.
+                        </p>
+                        {passwordErrors.length > 0 && (
+                            <ul className="mt-2 text-xs text-red-600 space-y-1">
+                                {passwordErrors.map((msg) => (
+                                    <li key={msg}>{msg}</li>
+                                ))}
+                            </ul>
+                        )}
+                    </div>
+                    <div className="form-control">
+                        <label className="label">
+                            <span className="label-text">Confirm password</span>
+                        </label>
+                        <input
+                            type="password"
+                            className="input input-bordered w-full"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            disabled={disabled}
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        className="btn w-full text-white"
+                        style={{ backgroundColor: "#6B8C8E" }}
+                        disabled={submitting || disabled}
+                    >
+                        {submitting ? "Resetting..." : "Reset password"}
+                    </button>
+                    <p className="text-sm text-center">
+                        Return to{" "}
+                        <Link to="/login" className="underline">
+                            login
+                        </Link>
+                        .
+                    </p>
+                </form>
+            </main>
+        </div>
+    );
+}

--- a/jewelrysite-frontend/src/routes/AppRouter.tsx
+++ b/jewelrysite-frontend/src/routes/AppRouter.tsx
@@ -4,6 +4,8 @@ import CatalogPage from "../pages/CatalogPage";
 import JewelryItemPage from "../pages/JewelryItemPage";
 import LoginPage from "../pages/LoginPage";
 import RegisterPage from "../pages/RegisterPage";
+import ForgotPasswordPage from "../pages/ForgotPasswordPage";
+import ResetPasswordPage from "../pages/ResetPasswordPage";
 import CartPage from "../pages/CartPage";
 import ControlPanelPage from "../pages/ControlPanelPage";
 
@@ -16,6 +18,8 @@ export default function AppRouter() {
                 <Route path="/item/:id" element={<JewelryItemPage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<RegisterPage />} />
+                <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+                <Route path="/reset-password" element={<ResetPasswordPage />} />
                 <Route path="/cart" element={<CartPage />} />
                 <Route path="/control-panel" element={<ControlPanelPage />} />
             </Routes>

--- a/jewelrysite-frontend/src/utils/passwordPolicy.ts
+++ b/jewelrysite-frontend/src/utils/passwordPolicy.ts
@@ -1,0 +1,22 @@
+export function validatePassword(password: string): string[] {
+    const errors: string[] = [];
+
+    if (!password || password.trim().length === 0) {
+        errors.push("Password is required.");
+        return errors;
+    }
+
+    if (password.length < 8) {
+        errors.push("Password must be at least 8 characters long.");
+    }
+
+    if (!/\d/.test(password)) {
+        errors.push("Password must include at least one digit.");
+    }
+
+    return errors;
+}
+
+export function isPasswordValid(password: string): boolean {
+    return validatePassword(password).length === 0;
+}


### PR DESCRIPTION
## Summary
- enforce the shared password policy during registration and return clear validation errors
- add forgot and reset password forms with API integrations and new router entries
- enhance registration and login screens with password guidance and a subtle forgot-password link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6693e48a48325937b20c82aeefecf