### PR TITLE
Add order checkout service and API

### DIFF
--- a/JewelrySite/Controllers/OrdersController.cs
+++ b/JewelrySite/Controllers/OrdersController.cs
@@ -1,0 +1,98 @@
+using JewelrySite.BL;
+using JewelrySite.DAL;
+using JewelrySite.DTO;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Security.Claims;
+
+namespace JewelrySite.Controllers
+{
+        [Route("api/[controller]")]
+        [ApiController]
+        [Authorize(Roles = "Customer,Admin")]
+        public class OrdersController : ControllerBase
+        {
+                private readonly OrderService _orderService;
+
+                public OrdersController(OrderService orderService)
+                {
+                        _orderService = orderService;
+                }
+
+                private bool TryResolveAuthorizedUserId(int? requestedUserId, out int userId, out ActionResult? errorResult)
+                {
+                        errorResult = null;
+                        userId = 0;
+
+                        string? userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                        if (!int.TryParse(userIdClaim, out int authenticatedUserId))
+                        {
+                                errorResult = Unauthorized();
+                                return false;
+                        }
+
+                        bool isAdmin = User.IsInRole("Admin");
+
+                        if (requestedUserId.HasValue)
+                        {
+                                if (!isAdmin && requestedUserId.Value != authenticatedUserId)
+                                {
+                                        errorResult = Forbid();
+                                        return false;
+                                }
+
+                                userId = requestedUserId.Value;
+                                return true;
+                        }
+
+                        userId = authenticatedUserId;
+                        return true;
+                }
+
+                [HttpPost]
+                public async Task<ActionResult<OrderConfirmationDto>> CreateOrder([FromBody] CreateOrderRequestDto request, int? userId)
+                {
+                        if (!TryResolveAuthorizedUserId(userId, out int resolvedUserId, out ActionResult? error))
+                        {
+                                return error!;
+                        }
+
+                        if (!ModelState.IsValid)
+                        {
+                                return ValidationProblem(ModelState);
+                        }
+
+                        try
+                        {
+                                Order order = await _orderService.CreateOrderAsync(resolvedUserId, request);
+                                var response = new OrderConfirmationDto
+                                {
+                                        OrderId = order.Id,
+                                        CreatedAt = order.CreatedAt,
+                                        Status = order.Status,
+                                        Subtotal = order.Subtotal,
+                                        Shipping = order.Shipping,
+                                        TaxVat = order.TaxVat,
+                                        DiscountTotal = order.DiscountTotal,
+                                        GrandTotal = order.GrandTotal,
+                                        CurrencyCode = order.CurrencyCode,
+                                        Items = order.Items.Select(oi => new OrderConfirmationItemDto
+                                        {
+                                                JewelryItemId = oi.JewelryItemId,
+                                                Name = oi.NameSnapshot,
+                                                UnitPrice = oi.UnitPrice,
+                                                Quantity = oi.Quantity,
+                                                LineTotal = oi.LineTotal
+                                        }).ToList()
+                                };
+
+                                return CreatedAtAction(nameof(CreateOrder), new { id = response.OrderId }, response);
+                        }
+                        catch (InvalidOperationException ex)
+                        {
+                                return BadRequest(ex.Message);
+                        }
+                }
+        }
+}

--- a/JewelrySite/DAL/JewerlyStoreDBContext.cs
+++ b/JewelrySite/DAL/JewerlyStoreDBContext.cs
@@ -8,9 +8,11 @@ namespace JewelrySite.DAL
 		public DbSet<JewelryItem> JewelryItems => Set<JewelryItem>();
 		public DbSet<JewelryImage> JewelryImages => Set<JewelryImage>();
 		public DbSet<User> Users => Set<User>();
-		public DbSet<CartItem> CartItems => Set<CartItem>();
-		public DbSet<Cart> Carts => Set<Cart>();
-		public DbSet<PasswordResetRequest> PasswordResetRequests => Set<PasswordResetRequest>();
+                public DbSet<CartItem> CartItems => Set<CartItem>();
+                public DbSet<Cart> Carts => Set<Cart>();
+                public DbSet<Order> Orders => Set<Order>();
+                public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+                public DbSet<PasswordResetRequest> PasswordResetRequests => Set<PasswordResetRequest>();
 
 
 

--- a/JewelrySite/DAL/OrderService.cs
+++ b/JewelrySite/DAL/OrderService.cs
@@ -1,0 +1,113 @@
+using JewelrySite.BL;
+using JewelrySite.DTO;
+using Microsoft.EntityFrameworkCore;
+
+namespace JewelrySite.DAL
+{
+        public class OrderService
+        {
+                private readonly JewerlyStoreDBContext _dbContext;
+
+                public OrderService(JewerlyStoreDBContext dbContext)
+                {
+                        _dbContext = dbContext;
+                }
+
+                public async Task<Order> CreateOrderAsync(int userId, CreateOrderRequestDto request, CancellationToken cancellationToken = default)
+                {
+                        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+                        try
+                        {
+                                var cart = await _dbContext.Carts
+                                        .Include(c => c.Items)
+                                        .ThenInclude(ci => ci.jewelryItem)
+                                        .FirstOrDefaultAsync(c => c.UserId == userId, cancellationToken);
+
+                                if (cart == null)
+                                {
+                                        throw new InvalidOperationException("Cart not found for user.");
+                                }
+
+                                if (!cart.Items.Any())
+                                {
+                                        throw new InvalidOperationException("Cannot create an order from an empty cart.");
+                                }
+
+                                decimal subtotal = 0m;
+                                decimal shipping = 0m;
+                                decimal tax = 0m;
+                                decimal discount = 0m;
+
+                                var order = new Order
+                                {
+                                        UserId = userId,
+                                        Status = OrderStatus.Pending,
+                                        CreatedAt = DateTime.UtcNow,
+                                        FullName = request.FullName,
+                                        Phone = request.Phone,
+                                        Country = request.Country,
+                                        City = request.City,
+                                        Street = request.Street,
+                                        PostalCode = request.PostalCode,
+                                        Notes = request.PaymentNotes,
+                                        PaymentProvider = request.PaymentMethod,
+                                        PaymentRef = request.PaymentReference,
+                                        CurrencyCode = string.IsNullOrWhiteSpace(request.CurrencyCode) ? "ILS" : request.CurrencyCode!
+                                };
+
+                                foreach (var cartItem in cart.Items)
+                                {
+                                        if (cartItem.jewelryItem == null)
+                                        {
+                                                cartItem.jewelryItem = await _dbContext.JewelryItems
+                                                        .FirstOrDefaultAsync(j => j.Id == cartItem.jewelryItemId, cancellationToken);
+                                        }
+
+                                        var unitPrice = cartItem.priceAtAddTime;
+                                        var quantity = cartItem.quantity;
+                                        var lineTotal = unitPrice * quantity;
+
+                                        subtotal += lineTotal;
+                                        shipping = Math.Max(shipping, cartItem.jewelryItem?.ShippingPrice ?? 0m);
+
+                                        order.Items.Add(new OrderItem
+                                        {
+                                                JewelryItemId = cartItem.jewelryItemId,
+                                                NameSnapshot = cartItem.jewelryItem?.Name,
+                                                UnitPrice = unitPrice,
+                                                Quantity = quantity,
+                                                LineTotal = lineTotal
+                                        });
+                                }
+
+                                // Future extension hooks
+                                tax = request.TaxAmount ?? tax;
+                                discount = request.DiscountAmount ?? discount;
+
+                                order.Subtotal = subtotal;
+                                order.Shipping = shipping;
+                                order.TaxVat = tax;
+                                order.DiscountTotal = discount;
+                                order.GrandTotal = subtotal + shipping + tax - discount;
+
+                                _dbContext.Orders.Add(order);
+
+                                // remove cart items to mark checkout completion
+                                var itemsToRemove = cart.Items.ToList();
+                                _dbContext.CartItems.RemoveRange(itemsToRemove);
+                                cart.Items.Clear();
+
+                                await _dbContext.SaveChangesAsync(cancellationToken);
+                                await transaction.CommitAsync(cancellationToken);
+
+                                return order;
+                        }
+                        catch
+                        {
+                                await transaction.RollbackAsync(cancellationToken);
+                                throw;
+                        }
+                }
+        }
+}

--- a/JewelrySite/DTO/OrderDtos.cs
+++ b/JewelrySite/DTO/OrderDtos.cs
@@ -1,0 +1,68 @@
+using JewelrySite.BL;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace JewelrySite.DTO
+{
+        public class CreateOrderRequestDto
+        {
+                [Required, MaxLength(100)]
+                public string FullName { get; set; } = string.Empty;
+
+                [Required, MaxLength(30)]
+                public string Phone { get; set; } = string.Empty;
+
+                [Required, MaxLength(60)]
+                public string Country { get; set; } = string.Empty;
+
+                [Required, MaxLength(60)]
+                public string City { get; set; } = string.Empty;
+
+                [Required, MaxLength(120)]
+                public string Street { get; set; } = string.Empty;
+
+                [MaxLength(20)]
+                public string? PostalCode { get; set; }
+
+                [MaxLength(32)]
+                public string? PaymentMethod { get; set; }
+
+                [MaxLength(128)]
+                public string? PaymentReference { get; set; }
+
+                [MaxLength(500)]
+                public string? PaymentNotes { get; set; }
+
+                [MaxLength(3)]
+                public string? CurrencyCode { get; set; }
+
+                [Range(0, double.MaxValue)]
+                public decimal? TaxAmount { get; set; }
+
+                [Range(0, double.MaxValue)]
+                public decimal? DiscountAmount { get; set; }
+        }
+
+        public class OrderConfirmationItemDto
+        {
+                public int JewelryItemId { get; set; }
+                public string? Name { get; set; }
+                public decimal UnitPrice { get; set; }
+                public int Quantity { get; set; }
+                public decimal LineTotal { get; set; }
+        }
+
+        public class OrderConfirmationDto
+        {
+                public int OrderId { get; set; }
+                public DateTime CreatedAt { get; set; }
+                public OrderStatus Status { get; set; }
+                public decimal Subtotal { get; set; }
+                public decimal Shipping { get; set; }
+                public decimal TaxVat { get; set; }
+                public decimal DiscountTotal { get; set; }
+                public decimal GrandTotal { get; set; }
+                public string CurrencyCode { get; set; } = "ILS";
+                public IEnumerable<OrderConfirmationItemDto> Items { get; set; } = Enumerable.Empty<OrderConfirmationItemDto>();
+        }
+}

--- a/JewelrySite/Program.cs
+++ b/JewelrySite/Program.cs
@@ -31,7 +31,8 @@ namespace JewelrySite
 
             builder.Services.AddDbContext<JewerlyStoreDBContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnectionDB")));
 
-			builder.Services.AddScoped<CartService>();
+                        builder.Services.AddScoped<CartService>();
+                        builder.Services.AddScoped<OrderService>();
 			builder.Services.AddScoped<JewelryItemService>();
 			builder.Services.AddScoped<AuthService>();
 			EmailService.Init(builder.Configuration);


### PR DESCRIPTION
## Summary
- add an order service that snapshots the cart into persistent orders within a transaction
- expose an authenticated OrdersController endpoint that accepts checkout details and returns a confirmation payload
- register the new service/DTOs and extend the DbContext with order sets

## Testing
- dotnet build (fails: dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68de3ad589d883259a19c8592a434f1a