### PR TITLE
Route PayPal REST calls through backend endpoints

### DIFF
--- a/JewelrySite/HelperClasses/OrderResponseFactory.cs
+++ b/JewelrySite/HelperClasses/OrderResponseFactory.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using JewelrySite.BL;
+using JewelrySite.DTO;
+
+namespace JewelrySite.HelperClasses
+{
+    public static class OrderResponseFactory
+    {
+        public static OrderConfirmationDto BuildOrderConfirmation(
+            Order order,
+            string? payPalOrderIdOverride = null,
+            string? payPalStatusOverride = null,
+            string? approvalUrl = null,
+            string? captureIdOverride = null)
+        {
+            var (storedOrderId, storedCaptureId) = PaymentReferenceHelper.Parse(order.PaymentRef);
+            var items = order.Items.Select(oi => new OrderConfirmationItemDto
+            {
+                JewelryItemId = oi.JewelryItemId,
+                Name = oi.NameSnapshot,
+                UnitPrice = oi.UnitPrice,
+                Quantity = oi.Quantity,
+                LineTotal = oi.LineTotal
+            }).ToList();
+
+            string? resolvedStatus = payPalStatusOverride;
+            if (string.IsNullOrWhiteSpace(resolvedStatus))
+            {
+                if (!string.IsNullOrWhiteSpace(captureIdOverride ?? storedCaptureId) || order.Status == OrderStatus.Paid)
+                {
+                    resolvedStatus = "COMPLETED";
+                }
+                else if (!string.IsNullOrWhiteSpace(payPalOrderIdOverride ?? storedOrderId))
+                {
+                    resolvedStatus = "CREATED";
+                }
+            }
+
+            return new OrderConfirmationDto
+            {
+                OrderId = order.Id,
+                CreatedAt = order.CreatedAt,
+                Status = order.Status,
+                Subtotal = order.Subtotal,
+                Shipping = order.Shipping,
+                TaxVat = order.TaxVat,
+                DiscountTotal = order.DiscountTotal,
+                GrandTotal = order.GrandTotal,
+                CurrencyCode = order.CurrencyCode,
+                PaymentProvider = order.PaymentProvider,
+                PaymentReference = order.PaymentRef,
+                PayPalOrderId = payPalOrderIdOverride ?? storedOrderId,
+                PayPalCaptureId = captureIdOverride ?? storedCaptureId,
+                PayPalApprovalUrl = approvalUrl,
+                PayPalStatus = resolvedStatus,
+                Items = items
+            };
+        }
+    }
+}

--- a/jewelrysite-frontend/src/api/orders.ts
+++ b/jewelrysite-frontend/src/api/orders.ts
@@ -9,12 +9,12 @@ import type {
 } from "../types/Order";
 
 export async function createOrder(payload: CreateOrderPayload): Promise<CheckoutPreparationResponse> {
-    const res = await http.post<CheckoutPreparationResponse>("/api/Orders", payload);
+    const res = await http.post<CheckoutPreparationResponse>("/api/paypal/create-order", payload);
     return res.data;
 }
 
 export async function completeOrder(payload: CompleteOrderPayload): Promise<OrderConfirmationResponse> {
-    const res = await http.post<OrderConfirmationResponse>("/api/Orders/complete", payload);
+    const res = await http.post<OrderConfirmationResponse>("/api/paypal/capture-order", payload);
     return res.data;
 }
 

--- a/jewelrysite-frontend/src/hooks/usePayPalScript.ts
+++ b/jewelrysite-frontend/src/hooks/usePayPalScript.ts
@@ -23,11 +23,18 @@ export interface PayPalButtonsInstance {
     close(): Promise<void> | void;
 }
 
+export interface PayPalButtonsActions {
+    enable(): Promise<void> | void;
+    disable(): Promise<void> | void;
+}
+
 export interface PayPalButtonsConfig {
     style?: Record<string, unknown>;
     createOrder?: () => string | Promise<string>;
     onApprove?: (data: PayPalApproveData) => void | Promise<void>;
+    onCancel?: () => void;
     onError?: (err: unknown) => void;
+    onInit?: (data: unknown, actions: PayPalButtonsActions) => void | Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- add a dedicated PayPal controller that proxies create and capture operations through the backend
- share order confirmation mapping logic via a reusable factory
- update the frontend API and PayPal typings to call the new endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8d0149efc83258112e22fda254fda